### PR TITLE
Spock integration tests support

### DIFF
--- a/GuardGrailsPlugin.groovy
+++ b/GuardGrailsPlugin.groovy
@@ -8,6 +8,8 @@ class GuardGrailsPlugin {
     // the other plugins this plugin depends on
     def dependsOn = [:]
 
+    def loadAfter = ['spock']
+
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
         "grails-app/views/error.gsp"

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,5 +21,8 @@ grails.project.dependency.resolution = {
         build(":tomcat:$grailsVersion", ":release:2.0.3") {
             export = false
         }
+        test(":spock:0.6") {
+            export = false
+        }
     }
 }

--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -2,11 +2,20 @@ import org.codehaus.groovy.grails.test.junit4.JUnit4GrailsTestType
 import org.codehaus.groovy.grails.test.support.GrailsTestMode
 
 guardTests = []
+guardSpock = false
+
 
 loadGuardTestTypes = {
     phasesToRun << "guard"
     def mode = new GrailsTestMode(autowire: true, wrapInTransaction: true, wrapInRequestEnvironment: true)
     guardTests << new JUnit4GrailsTestType("guard", "integration", mode)
+
+    // if spock is loaded
+    if (binding.variables.containsKey("loadSpecTestTypeClass")) {
+        def specTestTypeClass = loadSpecTestTypeClass()
+        guardSpock = true
+        guardTests << specTestTypeClass.newInstance('spock', 'integration')
+    }
 }
 
 // Guard testing uses the same startup as integration

--- a/test/integration/guard/grails/SampleServiceSpec.groovy
+++ b/test/integration/guard/grails/SampleServiceSpec.groovy
@@ -1,0 +1,17 @@
+package guard.grails
+import grails.plugin.spock.IntegrationSpec
+
+import spock.lang.*
+
+class SampleServiceSpec extends IntegrationSpec {
+
+	def sampleService
+
+	def "injected sampleService is present"() {
+	    when:
+	    	def msg = sampleService.helloWorld()
+
+	    then:
+	    	msg == "Hello World!"
+  }
+}


### PR DESCRIPTION
Hello,

your plugin is really helpful but our integration tests are mostly comprised of Spock tests. I have added somewhat quick and dirty support for Spock reloading in grails-guard. What is still missing is choosing to run only spock tests or only classical test with guard:spock or guard:integration.

Best regards.

Julien
